### PR TITLE
add: APIリクエストの受け口を追加

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,5 @@
 module backend
 
 go 1.24.1
+
+require github.com/gorilla/mux v1.8.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=


### PR DESCRIPTION
- [x] タスク一覧の取得 (`GET /tasks`)ができること
```bash
curl -X GET http://localhost:8080/tasks
```
- [x] 新しいタスクの作成 (`POST /tasks`)ができること
```bash
curl -X POST http://localhost:8080/tasks \
-H "Content-Type: application/json" \
-d '{"title":"Sample Task","content":"This is a sample task."}'
```
- [x] タスクの削除 (`DELETE /tasks/{id}`)ができること
```bash
curl -X DELETE http://localhost:8080/tasks/1
```